### PR TITLE
Audio support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **New Endpoints**:
+    - **Audio**:
+        - `createAudioTranscription`: Create transcriptions from audio files using the Mistral audio transcription API.
+            - Supports multipart file uploads for audio files.
+            - Supports streaming responses with optional callback mechanism.
+            - Compatible with various audio formats as supported by the Mistral API.
+
+- **New Tests**:
+    - Added comprehensive test coverage for the `createAudioTranscription` method.
+    - Created test fixture for audio transcription responses (`tests/fixtures/responses/createAudioTranscription.json`).
+
+- **Documentation Updates**:
+    - Updated README.md to include the new Audio Transcription endpoint in the "Supported Methods" section.
+    - Added method signature and documentation for `createAudioTranscription`.
+
 ## [2.0.0] - 2024-10-06
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -85,16 +85,38 @@ $streamCallback = static function ($data) {
     }
 };
 
-$mistral->createChatCompletion([
-    'model' => 'mistral-small-latest',
-    'messages' => [
-        [
-            'role' => 'user',
-            'content' => 'Tell me a story about a brave knight.',
+$mistral->createChatCompletion(
+    [],
+    [
+        'model' => 'mistral-small-latest',
+        'messages' => [
+            [
+                'role' => 'user',
+                'content' => 'Tell me a story about a brave knight.',
+            ],
         ],
+        'stream' => true,
     ],
-    'stream' => true,
-], $streamCallback);
+    $streamCallback
+);
+```
+
+### Audio Transcription Example
+
+You can transcribe audio files using the audio transcription endpoint:
+
+```php
+$response = $mistral->createAudioTranscription([], [
+    'file' => '/path/to/audio.mp3',
+    'model' => 'mistral-whisper',
+    'language' => 'en', // optional
+]);
+
+// Process the transcription response
+if ($response->getStatusCode() === 200) {
+    $result = json_decode($response->getBody()->getContents(), true);
+    echo $result['text']; // The transcribed text
+}
 ```
 
 For more details on how to use each endpoint, refer to the [Mistral API documentation](https://docs.mistral.ai), and the [examples](https://github.com/SoftCreatR/php-mistral-ai-sdk/tree/main/examples) provided in the repository.
@@ -155,7 +177,7 @@ For more details on how to use each endpoint, refer to the [Mistral API document
 
 ### Audio
 -   [Create Audio Transcription](https://docs.mistral.ai/api/endpoint/audio/transcriptions)
-    -   `createAudioTranscription(array $options = [], callable $streamCallback = null)`
+    -   `createAudioTranscription(array $parameters = [], array $options = [], callable $streamCallback = null)`
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can transcribe audio files using the audio transcription endpoint:
 ```php
 $response = $mistral->createAudioTranscription([], [
     'file' => '/path/to/audio.mp3',
-    'model' => 'mistral-whisper',
+    'model' => 'voxtral-mini-latest',
     'language' => 'en', // optional
 ]);
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ For more details on how to use each endpoint, refer to the [Mistral API document
     -   `createAgentsCompletion(array $options = [])`
 
 ### Audio
--   [Create Audio Transcription](https://docs.mistral.ai/api/endpoint/audio/transcriptions)
+-   [Create Audio Transcription](https://docs.mistral.ai/api/endpoint/audio/transcriptions) - [Example](https://github.com/SoftCreatR/php-mistral-ai-sdk/blob/main/examples/audio/createAudioTranscription.php)
     -   `createAudioTranscription(array $parameters = [], array $options = [], callable $streamCallback = null)`
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ For more details on how to use each endpoint, refer to the [Mistral API document
 -   [Create Agents Completion](https://docs.mistral.ai/api/#tag/agents/operation/agents_completion_v1_agents_completions_post) - [Example](https://github.com/SoftCreatR/php-mistral-ai-sdk/blob/main/examples/agents/createAgentsCompletion.php)
     -   `createAgentsCompletion(array $options = [])`
 
+### Audio
+-   [Create Audio Transcription](https://docs.mistral.ai/api/endpoint/audio/transcriptions)
+    -   `createAudioTranscription(array $options = [], callable $streamCallback = null)`
+
 ## Changelog
 
 For a detailed list of changes and updates, please refer to the [CHANGELOG.md](https://github.com/SoftCreatR/php-mistral-ai-sdk/blob/main/CHANGELOG.md) file. We adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and document notable changes for each release.

--- a/examples/audio/createAudioTranscription.php
+++ b/examples/audio/createAudioTranscription.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../MistralAIFactory.php';
  */
 MistralAIFactory::request('createAudioTranscription', [
     'file' => '/path/to/your/audio.mp3', // Replace with the actual audio file path
-    'model' => 'mistral-whisper',
+    'model' => 'voxtral-mini-latest',
     'language' => 'en', // Optional: Language of the audio (e.g., 'en', 'fr', 'es')
     'temperature' => 0.0, // Optional: Temperature for controlling randomness (0.0 - 1.0)
 ]);

--- a/examples/audio/createAudioTranscription.php
+++ b/examples/audio/createAudioTranscription.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2024, Sascha Greuel and Contributors
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+require_once __DIR__ . '/../MistralAIFactory.php';
+
+/**
+ * Example: Create an audio transcription.
+ *
+ * Model Description:
+ * Transcribes audio files into text using Mistral's audio transcription model.
+ * Supports various audio formats (mp3, wav, m4a, etc.) and optional parameters
+ * like language specification and temperature for controlling the output.
+ *
+ * OpenAPI Specification Reference:
+ * - Operation ID: create_transcription_v1_audio_transcriptions_post
+ * - Endpoint: POST /v1/audio/transcriptions
+ */
+MistralAIFactory::request('createAudioTranscription', [
+    'file' => '/path/to/your/audio.mp3', // Replace with the actual audio file path
+    'model' => 'mistral-whisper',
+    'language' => 'en', // Optional: Language of the audio (e.g., 'en', 'fr', 'es')
+    'temperature' => 0.0, // Optional: Temperature for controlling randomness (0.0 - 1.0)
+]);

--- a/src/MistralAI.php
+++ b/src/MistralAI.php
@@ -56,6 +56,7 @@ use const JSON_THROW_ON_ERROR;
  * @method ResponseInterface|null createFimCompletion(array $parameters, array $options = [], ?\Closure $callback = null) Perform a POST request to create a FIM completion.
  * @method ResponseInterface|null createAgentsCompletion(array $parameters, array $options = [], ?\Closure $callback = null) Perform a POST request to create an agents completion.
  * @method ResponseInterface|null createEmbedding(array $parameters, array $options = []) Perform a POST request to create an embedding.
+ * @method ResponseInterface|null createAudioTranscription(array $parameters, array $options = [], ?\Closure $callback = null) Perform a POST request to create an audio transcription.
  */
 class MistralAI
 {

--- a/src/MistralAIURLBuilder.php
+++ b/src/MistralAIURLBuilder.php
@@ -77,6 +77,9 @@ final class MistralAIURLBuilder
 
         // Embeddings
         'createEmbedding' => ['method' => self::HTTP_METHOD_POST,   'path' => '/embeddings'],
+
+        // Audio
+        'createAudioTranscription' => ['method' => self::HTTP_METHOD_POST, 'path' => '/audio/transcriptions'],
     ];
 
     /**

--- a/tests/MistralAITest.php
+++ b/tests/MistralAITest.php
@@ -668,6 +668,27 @@ class MistralAITest extends TestCase
     }
 
     /**
+     * Tests that the createAudioTranscription method handles API calls correctly.
+     *
+     * @throws Exception
+     */
+    public function testCreateAudioTranscription(): void
+    {
+        $filePath = __DIR__ . '/fixtures/dummyAudio.mp3';
+        \file_put_contents($filePath, 'Dummy audio content');
+
+        $this->testApiCall(
+            fn() => $this->mistralAI->createAudioTranscription([
+                'file' => $filePath,
+                'model' => 'mistral-whisper',
+            ]),
+            'createAudioTranscription.json'
+        );
+
+        \unlink($filePath);
+    }
+
+    /**
      * Tests the 'extractCallArguments' method with various input scenarios.
      *
      * Ensures that the method correctly extracts parameters, options, and the stream callback from the provided arguments.

--- a/tests/MistralAITest.php
+++ b/tests/MistralAITest.php
@@ -689,7 +689,7 @@ class MistralAITest extends TestCase
         // Pass file in options (second parameter), not in parameters
         $response = $this->mistralAI->createAudioTranscription([], [
             'file' => $filePath,
-            'model' => 'mistral-whisper',
+            'model' => 'voxtral-mini-latest',
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/fixtures/responses/createAudioTranscription.json
+++ b/tests/fixtures/responses/createAudioTranscription.json
@@ -1,0 +1,34 @@
+{
+  "model": "mistral-whisper",
+  "text": "This is a test audio transcription.",
+  "language": "en",
+  "segments": [
+    {
+      "id": 0,
+      "start": 0.0,
+      "end": 2.5,
+      "text": "This is a test",
+      "tokens": [1234, 5678, 9012, 3456],
+      "temperature": 0.0,
+      "avg_logprob": -0.25,
+      "compression_ratio": 1.2,
+      "no_speech_prob": 0.01
+    },
+    {
+      "id": 1,
+      "start": 2.5,
+      "end": 4.0,
+      "text": " audio transcription.",
+      "tokens": [7890, 1234, 5678],
+      "temperature": 0.0,
+      "avg_logprob": -0.22,
+      "compression_ratio": 1.1,
+      "no_speech_prob": 0.02
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 0,
+    "completion_tokens": 15,
+    "total_tokens": 15
+  }
+}

--- a/tests/fixtures/responses/createAudioTranscription.json
+++ b/tests/fixtures/responses/createAudioTranscription.json
@@ -1,34 +1,12 @@
 {
-  "model": "mistral-whisper",
+  "model": "voxtral-mini-latest",
   "text": "This is a test audio transcription.",
   "language": "en",
-  "segments": [
-    {
-      "id": 0,
-      "start": 0.0,
-      "end": 2.5,
-      "text": "This is a test",
-      "tokens": [1234, 5678, 9012, 3456],
-      "temperature": 0.0,
-      "avg_logprob": -0.25,
-      "compression_ratio": 1.2,
-      "no_speech_prob": 0.01
-    },
-    {
-      "id": 1,
-      "start": 2.5,
-      "end": 4.0,
-      "text": " audio transcription.",
-      "tokens": [7890, 1234, 5678],
-      "temperature": 0.0,
-      "avg_logprob": -0.22,
-      "compression_ratio": 1.1,
-      "no_speech_prob": 0.02
-    }
-  ],
+  "segments": [],
   "usage": {
-    "prompt_tokens": 0,
-    "completion_tokens": 15,
-    "total_tokens": 15
+    "prompt_audio_seconds": 203,
+    "prompt_tokens": 4,
+    "completion_tokens": 635,
+    "total_tokens": 3264
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

# 🔀 Pull Request

## What does this PR do?

It adds support for [Audio Transcription endpoints](https://docs.mistral.ai/api/endpoint/audio/transcriptions):
- Create Transcription
- Create Streaming Transcription (SSE)

Changelog straight from `CHANGELOG.md`:
```
Added

- New Endpoints:
    - Audio:
        - `createAudioTranscription`: Create transcriptions from audio files using the Mistral audio transcription API.
            - Supports multipart file uploads for audio files.
            - Supports streaming responses with optional callback mechanism.
            - Compatible with various audio formats as supported by the Mistral API.

- New Tests:
    - Added comprehensive test coverage for the `createAudioTranscription` method.
    - Created test fixture for audio transcription responses (`tests/fixtures/responses/createAudioTranscription.json`).

- Documentation Updates:
    - Updated README.md to include the new Audio Transcription endpoint in the "Supported Methods" section.
    - Added method signature and documentation for `createAudioTranscription`.
```

## Test Plan

There's only one test case `testCreateAudioTranscription` that ensures the request is sent with correct `Content-Type` header and correct body.

I tested it manually and it works as expected. I didn't test stream though.

## Related PRs and Issues

https://github.com/SoftCreatR/php-mistral-ai-sdk/issues/2
